### PR TITLE
Bind DefaultSqsService

### DIFF
--- a/src/main/java/smartthings/ratpack/sqs/SqsModule.java
+++ b/src/main/java/smartthings/ratpack/sqs/SqsModule.java
@@ -25,6 +25,11 @@ public class SqsModule extends ConfigurableModule<SqsModule.Config> {
 
         OptionalBinder.newOptionalBinder(binder(), AmazonSQSProvider.class)
             .setDefault().to(DefaultAmazonSQSProvider.class);
+        
+        OptionalBinder.newOptionalBinder(binder(), SqsService.class)
+            .setDefault()
+            .to(DefaultSqsService.class);
+        
     }
 
     /**


### PR DESCRIPTION
When attempting to inject the SqsService, I received the following error:
```
1) No implementation for smartthings.ratpack.sqs.SqsService was bound.
  while locating smartthings.ratpack.sqs.SqsService
    for the 1st parameter of smartthings.pooch.queue.QueueService.<init>(QueueService.groovy:28)
  at sun.reflect.GeneratedMethodAccessor6.invoke(Unknown Source) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> smartthings.pooch.PoochModule)
```

Therefore, I'm adding an optional binding, similar to the SnsService.